### PR TITLE
 feat: 네브바에 들어갈 버튼 공용 컴포넌트 구현 #10

### DIFF
--- a/src/components/BaseButton/BaseButton.module.css
+++ b/src/components/BaseButton/BaseButton.module.css
@@ -1,0 +1,18 @@
+.baseButton {
+  display: flex;
+  width: 120px;
+  height: 48px;
+  padding: 14px 46px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+
+  border-radius: 8px;
+  border: 1px solid #d9d9d9;
+  background: #fff;
+}
+
+.baseButtonImg{
+  width: 20px;
+  height: 20px;
+}

--- a/src/components/BaseButton/BaseButton.module.css
+++ b/src/components/BaseButton/BaseButton.module.css
@@ -12,7 +12,13 @@
   background: #fff;
 }
 
-.baseButtonImg{
+.baseButtonImg {
   width: 20px;
   height: 20px;
+}
+
+@media (max-width: 375px) {
+  .baseButtonImg {
+    display: none;
+  }
 }

--- a/src/components/BaseButton/BaseButton.tsx
+++ b/src/components/BaseButton/BaseButton.tsx
@@ -1,0 +1,17 @@
+import style from './BaseButton.module.css';
+
+interface BaseButtonProps {
+  onClick: () => void;
+  text: string;
+  image?: string;
+}
+
+function BaseButton({ onClick, text, image }: BaseButtonProps) {
+  return (
+    <button className={style.baseButton} onClick={onClick}>
+      {image && <img className={style.baseButtonImg} src={image} alt="button-img" />} {text}
+    </button>
+  );
+}
+
+export default BaseButton;


### PR DESCRIPTION
네브바에 들어갈 공통컴포넌트 구현했습니다.

이미지가 있으면 네브바에 사용가능하며
이미지가 없으면 모달에 취소용으롣도 사용할 수있습니다.

![image](https://github.com/taskify-team7/taskify/assets/33426203/43e03bde-6068-4d96-8a63-12b5f374c341)
![image](https://github.com/taskify-team7/taskify/assets/33426203/98315fe1-decc-49c3-9941-a86258097a2c)
