### PR TITLE
마이페이지 가로스크롤, 프로필 닉네임 변경 수정

### DIFF
--- a/src/components/Input/ProfileImgInput.module.css
+++ b/src/components/Input/ProfileImgInput.module.css
@@ -85,4 +85,8 @@
     width: 100px;
     height: 100px;
   }
+  }
+
+.profileImg{
+  object-fit: cover;
 }

--- a/src/components/Input/ProfileImgInput.tsx
+++ b/src/components/Input/ProfileImgInput.tsx
@@ -10,7 +10,7 @@ function ProfileImgInput({
   initialImg,
 }: ProfileImgInputType) {
   const imageInput = useRef<HTMLInputElement | null>(null);
-  const [pickedImage, setPickedImage] = useState<any>();
+  const [pickedImage, setPickedImage] = useState<any>(null);
 
   const handleImageInput = () => {
     imageInput.current?.click();

--- a/src/components/Input/ProfileImgInput.tsx
+++ b/src/components/Input/ProfileImgInput.tsx
@@ -1,12 +1,13 @@
-import React, { ChangeEvent, useRef, useState } from 'react';
-import style from './ProfileImgInput.module.css';
-import { ProfileImgInputType } from '../../interface/Input';
-import { changeImageURL } from '../../api/auth';
+import React, { ChangeEvent, useRef, useState } from "react";
+import style from "./ProfileImgInput.module.css";
+import { ProfileImgInputType } from "../../interface/Input";
+import { changeImageURL } from "../../api/auth";
 
 function ProfileImgInput({
   value,
   validation,
   setValue,
+  initialImg,
 }: ProfileImgInputType) {
   const imageInput = useRef<HTMLInputElement | null>(null);
   const [pickedImage, setPickedImage] = useState<any>();
@@ -27,7 +28,7 @@ function ProfileImgInput({
       setPickedImage(fileReader.result);
     };
     const image = await changeImageURL(file);
-    setValue('imageUrl', image);
+    setValue("imageUrl", image);
   };
 
   return (
@@ -48,7 +49,11 @@ function ProfileImgInput({
         {pickedImage ? (
           <>
             <div className={style.profileImgCover} onClick={handleImageInput}>
-              <img className={style.penImg} src="/Icons/edit_pen.svg" alt="edit" />
+              <img
+                className={style.penImg}
+                src="/Icons/edit_pen.svg"
+                alt="edit"
+              />
             </div>
             <img
               className={style.profilePickImg}
@@ -63,7 +68,11 @@ function ProfileImgInput({
               className={style.profileImgBtn}
               onClick={handleImageInput}
             >
-              <img src="/Icons/add_icon.svg" alt="add_Image" />
+              <img
+                className={initialImg ? style.profilePickImg : ""}
+                src={initialImg ? initialImg : "/Icons/add_icon.svg"}
+                alt="add_Image"
+              />
             </button>
           </>
         )}
@@ -71,5 +80,6 @@ function ProfileImgInput({
     </div>
   );
 }
+// "/Icons/add_icon.svg"
 
 export default ProfileImgInput;

--- a/src/components/ProfileModify/ProfileModify.tsx
+++ b/src/components/ProfileModify/ProfileModify.tsx
@@ -6,15 +6,10 @@ import ProfileImgInput from "../Input/ProfileImgInput";
 import { changeMyInfo } from "../../api/auth";
 
 export default function ProfileModify() {
-
-  let userEmail = "";
-  let userImg = "";
-  const userString = localStorage.getItem("user");
-  if (userString) {
-    const userObject = JSON.parse(userString);
-    userEmail = userObject.email;
-    userImg = userObject.profileImageUrl;
-  }
+  const userString = localStorage.getItem("user") || "";
+  const userObject = JSON.parse(userString);
+  const userEmail = userObject.email;
+  const userImg = userObject.profileImageUrl;
 
   const {
     register,

--- a/src/components/ProfileModify/ProfileModify.tsx
+++ b/src/components/ProfileModify/ProfileModify.tsx
@@ -1,22 +1,20 @@
-import style from './ProfileModify.module.css';
-import BaseButton from '../BaseButton/BaseButton';
-import CommonInput from '../Input/CommonInput';
-import { useForm } from 'react-hook-form';
-import ProfileImgInput from '../Input/ProfileImgInput';
-import { changeMyInfo } from '../../api/auth';
+import style from "./ProfileModify.module.css";
+import BaseButton from "../BaseButton/BaseButton";
+import CommonInput from "../Input/CommonInput";
+import { useForm } from "react-hook-form";
+import ProfileImgInput from "../Input/ProfileImgInput";
+import { changeMyInfo } from "../../api/auth";
 
 export default function ProfileModify() {
-  let userEmail = '';
-  let userImg = '';
-  const userString = localStorage.getItem('user');
+
+  let userEmail = "";
+  let userImg = "";
+  const userString = localStorage.getItem("user");
   if (userString) {
     const userObject = JSON.parse(userString);
     userEmail = userObject.email;
     userImg = userObject.profileImageUrl;
   }
-
-  console.log(userImg);
-  
 
   const {
     register,
@@ -24,20 +22,21 @@ export default function ProfileModify() {
     handleSubmit,
     setValue,
   } = useForm({
-    mode: 'onBlur',
+    mode: "onBlur",
     defaultValues: {
-      nickName: '',
-      imageUrl: '',
+      nickName: "",
+      imageUrl: null,
     },
   });
 
-  const imageValidation = register('imageUrl');
+  const imageValidation = register("imageUrl");
 
   const onSubmit = async (data: any) => {
     const profileData = {
       nickname: data.nickName,
-      profileImageUrl: data.imageUrl,
+      ...(data.imageUrl ? { profileImageUrl: data.imageUrl } : {}),
     };
+
     try {
       const res = await changeMyInfo(profileData);
     } catch (error) {
@@ -51,18 +50,22 @@ export default function ProfileModify() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className={style.totalInputContainer}>
           <div className={style.imgInputContainer}>
-            <ProfileImgInput initialImg = {userImg} validation={imageValidation} setValue={setValue} />
+            <ProfileImgInput
+              initialImg={userImg}
+              validation={imageValidation}
+              setValue={setValue}
+            />
           </div>
           <div className={style.commonInputContainer}>
             <CommonInput
-              label={'이메일'}
+              label={"이메일"}
               placeholder={userEmail}
               disabled={true}
             />
             <CommonInput
-              label={'닉네임'}
+              label={"닉네임"}
               placeholder="닉네임 입력"
-              validation={register('nickName')}
+              validation={register("nickName")}
             />
           </div>
         </div>

--- a/src/components/ProfileModify/ProfileModify.tsx
+++ b/src/components/ProfileModify/ProfileModify.tsx
@@ -7,11 +7,16 @@ import { changeMyInfo } from '../../api/auth';
 
 export default function ProfileModify() {
   let userEmail = '';
+  let userImg = '';
   const userString = localStorage.getItem('user');
   if (userString) {
     const userObject = JSON.parse(userString);
     userEmail = userObject.email;
+    userImg = userObject.profileImageUrl;
   }
+
+  console.log(userImg);
+  
 
   const {
     register,
@@ -35,7 +40,6 @@ export default function ProfileModify() {
     };
     try {
       const res = await changeMyInfo(profileData);
-      alert('프로필이 변경되었습니다.');
     } catch (error) {
       console.log(error);
     }
@@ -47,7 +51,7 @@ export default function ProfileModify() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className={style.totalInputContainer}>
           <div className={style.imgInputContainer}>
-            <ProfileImgInput validation={imageValidation} setValue={setValue} />
+            <ProfileImgInput initialImg = {userImg} validation={imageValidation} setValue={setValue} />
           </div>
           <div className={style.commonInputContainer}>
             <CommonInput

--- a/src/interface/Input.ts
+++ b/src/interface/Input.ts
@@ -28,4 +28,5 @@ export interface ImageInputType extends CommonInputType {
 
 export interface ProfileImgInputType extends CommonInputType {
   setValue: any;
+  initialImg: string;
 }

--- a/src/pages/MyPage/MyPage.module.css
+++ b/src/pages/MyPage/MyPage.module.css
@@ -8,6 +8,13 @@
 
   overflow: auto;
 }
+
+@media (max-width: 767px) {
+  .container {
+    padding: 12px;
+  }
+}
+
 .goBack {
   display: flex;
   width: 82px;


### PR DESCRIPTION
# 마이페이지 가로스크롤, 프로필 닉네임 변경 수정

## 작업 내용
1. 마이페이지 반응형 css 수정
2. 프로필 이미지가 있을 때 기존 이미지 가져오기
3. 프로필 이미지가 없을 때 닉네임만 변경 가능

## 스크린샷
![image](https://github.com/taskify-team7/taskify/assets/33426203/ebe861d5-34ae-4663-9f98-7e9f2881e255)
![image](https://github.com/taskify-team7/taskify/assets/33426203/7825a6c5-7ade-412f-b01d-99a70df4acfb)


## 참고 사항
닉네임 변경 후 로그아웃을 해야 변경됨.
비밀번호는 문제없이 정상 작동함 

## 해당 이슈 번호( #18 )