### PR TITLE
닉네임 수정 시 헤더의 닉네임도 즉시 변경

### DIFF
--- a/src/components/ProfileModify/ProfileModify.tsx
+++ b/src/components/ProfileModify/ProfileModify.tsx
@@ -10,6 +10,7 @@ export default function ProfileModify() {
   const userObject = JSON.parse(userString);
   const userEmail = userObject.email;
   const userImg = userObject.profileImageUrl;
+  console.log(userObject.nickname="??");
 
   const {
     register,
@@ -34,6 +35,8 @@ export default function ProfileModify() {
 
     try {
       const res = await changeMyInfo(profileData);
+      userObject.nickname = data.nickName;
+      localStorage.setItem("user", JSON.stringify(userObject))
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
# 마이페이지 닉네임 변경 시 헤더의 닉네임도 변경

## 작업 내용
1. 마이페이지 닉네임 변경 onSubmit 함수에 setItem을 통해 최신화된 닉네임 적용

## 스크린샷


## 참고 사항


## 해당 이슈 번호( #18  )